### PR TITLE
Adding example modal component

### DIFF
--- a/components/Modals/exampleModal/exampleModal.css
+++ b/components/Modals/exampleModal/exampleModal.css
@@ -1,0 +1,32 @@
+.modal {
+  display: none; /* Hidden by default */
+  position: fixed; /* Stay in place */
+  z-index: 1; /* Sit on top on z-index */
+  left: 0;
+  top: 0;
+  width: 100%; 
+  height: 100%; 
+  background-color: rgba(0,0,0,0.5); /* Black background with opacity */
+}
+
+.modal-content {
+  background-color: white;
+  margin: 15% auto;
+  padding: 20px;
+  border: 1px solid #888;
+  width: 80%; /* Could be more or less, depending on screen size */
+}
+
+.close {
+  color: #aaa;
+  float: right;
+  font-size: 28px;
+  font-weight: bold;
+}
+
+.close:hover,
+.close:focus {
+  color: black;
+  text-decoration: none;
+  cursor: pointer;
+}

--- a/components/Modals/exampleModal/exampleModal.html
+++ b/components/Modals/exampleModal/exampleModal.html
@@ -1,0 +1,11 @@
+<!-- Trigger Button -->
+<button id="openModal">Open Modal</button>
+
+<!-- The Modal -->
+<div id="myModal" class="modal">
+  <!-- Modal Content -->
+  <div class="modal-content">
+    <span class="close">&times;</span>
+    <p>This is a simple modal!</p>    
+  </div>
+</div>

--- a/components/Modals/exampleModal/exampleModal.js
+++ b/components/Modals/exampleModal/exampleModal.js
@@ -1,0 +1,20 @@
+const modal = document.getElementById("myModal");
+const btn = document.getElementById("openModal");
+const span = document.getElementsByClassName("close")[0];
+
+// When the user clicks the trigger button, open the modal
+btn.onclick = function() {
+  modal.style.display = "block";
+}
+
+// When the user clicks on (x), close the modal
+span.onclick = function() {
+  modal.style.display = "none";
+}
+
+// When the user clicks anywhere outside of the modal, close it
+window.onclick = function(event) {
+  if (event.target == modal) {
+    modal.style.display = "none";
+  }
+}

--- a/components/Modals/exampleModal/readme.md
+++ b/components/Modals/exampleModal/readme.md
@@ -1,0 +1,66 @@
+# Example Button Component
+
+## Description
+
+The Example Modal is a simple modal component that includes a trigger button that when pressed opens a modal overlay over the main content. It have a closing mechanism of an X that closes the modal. 
+The content of the modal can be modified to fit your own purpuses aswell as the styling an logic. 
+Its main purpose in this library is to showcase the structure of the library. 
+
+## Usage Instructions
+
+To use this component:
+1. You either need to include the trigger button, or if you want to use your own button give your button the id of "openModal" to let the js script find and create a node. 
+```html
+<button id="openModal">Open Modal</button>
+```
+
+2. **Include the HTML**:
+    ```html    
+    <div id="myModal" class="modal">      
+      <div class="modal-content">
+        <span class="close">&times;</span>
+        <p>This is a simple modal!</p>    
+      </div>
+    </div>
+    ```
+
+2. **Include the CSS**:
+    Link the CSS file in your HTML:
+    ```html
+    <link rel="stylesheet" href="./components/Modals/exampleModals/exampleModals.css">
+    ```
+    Alternatively, you can copy the CSS and paste it into your own stylesheet.
+
+3. **Include the JavaScript**:
+    Add the JavaScript file in your HTML:
+    ```html
+    <script src="./components/Modals/exampleModals/exampleModals.js"></script>
+    ```
+
+## Example Integration
+
+Here’s a complete example integrating the Example Modal component:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Simple Web Components Library</title>
+    <link rel="stylesheet" href="./components/Modals/exampleModals/exampleModals.css">
+</head>
+<body>
+    <h1>Simple Web Components Library</h1>
+   <button id="openModal">Open Modal</button>
+
+    <div id="myModal" class="modal">
+    
+      <div class="modal-content">
+        <span class="close">&times;</span>
+        <p>This is a simple modal!</p>    
+      </div>
+    </div>
+    <script src="./components/Modals/exampleModals/exampleModals.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Adding a complete modal component to showcase the structure of the library beter. it is complete with documentation and instructions on usage

## Description

Adding a new component. a modal that after activaded opens a overlay over the main content and can be closed with an "X" button.  it comes with a separate css and js file aswell as component specefik documentation.

## Related Issue

This PR closes #8  on merge 

## How Has This Been Tested?

Tests have been performed by running the files locally. 

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have tested my changes and confirmed that they work.
- [x] I have updated the documentation (if necessary).

## Additional Information

no further information needed